### PR TITLE
Made positional changes on Welcome Screen elements

### DIFF
--- a/MarvellOS.py
+++ b/MarvellOS.py
@@ -74,9 +74,9 @@ def welcome(o=""):
         home.after_cancel(Home.AFTER)
         home.destroy()
 
-    """Show button function"""
-
     def show():
+        """Show button function"""
+
         global sh
         if not sh:
             e["show"] = ""

--- a/MarvellOS.py
+++ b/MarvellOS.py
@@ -143,7 +143,7 @@ def welcome(o=""):
         fg="dark blue",
         font=("Curlz MT", 35),
     )
-    title_label.place(x=70, y=100)
+    title_label.place(x=47, y=100)
 
     shbtn = Button(
         welcome_screen,
@@ -181,7 +181,7 @@ def welcome(o=""):
         fg="black",
     )
     enterpass.place(x=96, y=215)
-    e = Entry(welcome_screen, show="*", width=30)
+    e = Entry(welcome_screen, show="*", width=27)
     e.focus_set()  # password entry field
     e.place(x=45, y=240)
 
@@ -199,7 +199,7 @@ def welcome(o=""):
         fg="red",
         font=("Century", 10, "bold"),
     )
-    inf.place(x=10, y=355)
+    inf.place(x=5, y=375)
     """Clock on the home screen"""
     global clock
     clock = Label(
@@ -1292,7 +1292,7 @@ class Home:
                 self.co = 1
 
     def change_password(self):
-        """Called when Change password button is pressed"""
+        """Called when 'Change Password' button is pressed"""
 
         global password
         self.passwin = Tk()

--- a/MarvellOS.py
+++ b/MarvellOS.py
@@ -61,7 +61,8 @@ def tick():
 
 
 def welcome(o=""):
-    """Function to open WELCOME SCREEN - Login screen that opens when you run."""
+    """Function to open WELCOME SCREEN - Login screen that opens when you
+        run."""
 
     global clock
     global welcome_screen
@@ -91,8 +92,7 @@ def welcome(o=""):
         confirmbtn["bg"] = "cyan"
         confirmbtn["state"] = "normal"
 
-
-    def confirm(event=None):  
+    def confirm(event=None):
         """Confirm button function"""
 
         global welcome_screen
@@ -342,7 +342,6 @@ class Home:
         lock.place(x=143, y=368)
 
         home.mainloop()
-
 
     def tick1(self):
         """Clock"""
@@ -1244,7 +1243,6 @@ class Home:
     except OverflowError:
         self.ans["text"] = "Out of range"
 
-
     def next(self):
         """Changing password"""
 
@@ -1365,10 +1363,9 @@ class Home:
             self.sh = False
             self.show.config(text="Show")
 
-
     def home_button1(self):
         """Home buttons for all screens"""
-        
+
         global home_screen  # home button for calculator
         self.calcwin.destroy()
         home_screen = Home()


### PR DESCRIPTION
Changes include - 

- Position of text on Welcome Screen to make it aligned
- Moved 'show' button docstring below it's definition 
- Enforced PEP8 by formatting blank lines, exceeding line length and trailing whitespaces ('self' issue is still not rectified)

On left is the Welcome Screen from before. On right is the Welcome Screen after.
![Screenshot from 2021-01-08 13-34-37](https://user-images.githubusercontent.com/70942982/103989836-4ea0f080-51b6-11eb-8c01-eee9f8ec00ec.png)

I request you to let me know if anything needs to be reverted, or changed further.

